### PR TITLE
Feat/#33

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=https://webridge-backend-development.up.railway.app/api/v1/

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@radix-ui/react-separator": "^1.1.7",
     "@radix-ui/react-slot": "^1.2.2",
     "@reduxjs/toolkit": "^2.8.1",
+    "async-mutex": "^0.5.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.510.0",

--- a/src/app/api.ts
+++ b/src/app/api.ts
@@ -1,13 +1,68 @@
 import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
+import type { BaseQueryFn } from "@reduxjs/toolkit/query";
+import { Mutex } from "async-mutex";
 
+// 동시 refresh 요청 방지를 위한 뮤텍스
+const mutex = new Mutex();
+
+// 기본 baseQuery (Authorization 헤더 포함)
+const baseQuery = fetchBaseQuery({
+  baseUrl: import.meta.env.VITE_API_BASE_URL,
+  prepareHeaders: (headers) => {
+    const token = localStorage.getItem("accessToken");
+    if (token) {
+      headers.set("Authorization", `Bearer ${token}`);
+    }
+    return headers;
+  },
+});
+
+// 커스텀 baseQuery - accessToken 만료 시 refreshToken으로 자동 갱신
+const customBaseQuery: BaseQueryFn = async (args, api, extraOptions) => {
+  await mutex.waitForUnlock();
+
+  let result = await baseQuery(args, api, extraOptions);
+
+  if (result.error?.status === 401) {
+    if (!mutex.isLocked()) {
+      const release = await mutex.acquire();
+
+      try {
+        const refreshToken = localStorage.getItem("refreshToken");
+
+        const refreshResult = await baseQuery(
+          {
+            url: "auth/token/refresh/",
+            method: "POST",
+            body: { refresh: refreshToken },
+          },
+          api,
+          extraOptions
+        );
+
+        const refreshData = refreshResult.data as { access: string };
+
+        if (refreshData?.access) {
+          localStorage.setItem("accessToken", refreshData.access);
+          result = await baseQuery(args, api, extraOptions);
+        } else {
+          localStorage.removeItem("accessToken");
+          localStorage.removeItem("refreshToken");
+        }
+      } finally {
+        release();
+      }
+    } else {
+      await mutex.waitForUnlock();
+      result = await baseQuery(args, api, extraOptions);
+    }
+  }
+
+  return result;
+};
+
+// RTK Query API 인스턴스 정의
 export const baseApi = createApi({
-  baseQuery: fetchBaseQuery({
-    baseUrl: import.meta.env.VITE_API_BASE_URL,
-    prepareHeaders: (headers) => {
-      const token = localStorage.getItem("accessToken");
-      if (token) headers.set("Authorization", `Bearer ${token}`);
-      return headers;
-    },
-  }),
+  baseQuery: customBaseQuery,
   endpoints: () => ({}),
 });

--- a/src/app/api.ts
+++ b/src/app/api.ts
@@ -1,0 +1,13 @@
+import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
+
+export const baseApi = createApi({
+  baseQuery: fetchBaseQuery({
+    baseUrl: import.meta.env.VITE_API_BASE_URL,
+    prepareHeaders: (headers) => {
+      const token = localStorage.getItem("accessToken");
+      if (token) headers.set("Authorization", `Bearer ${token}`);
+      return headers;
+    },
+  }),
+  endpoints: () => ({}),
+});

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -1,10 +1,14 @@
 import { configureStore } from "@reduxjs/toolkit";
 import counterReducer from "@/features/counterSlice";
+import { baseApi } from "@/app/api"; // baseApi 위치에 맞게 경로 수정
 
 export const store = configureStore({
   reducer: {
     counter: counterReducer,
+    [baseApi.reducerPath]: baseApi.reducer,
   },
+  middleware: (getDefaultMiddleware) =>
+    getDefaultMiddleware().concat(baseApi.middleware),
 });
 
 export type RootState = ReturnType<typeof store.getState>;

--- a/src/features/api/authApi.ts
+++ b/src/features/api/authApi.ts
@@ -1,0 +1,31 @@
+import { baseApi } from "@/app/api";
+
+interface RegisterRequest {
+  email: string;
+  password: string;
+  password2: string;
+  name: string;
+}
+
+interface RegisterResponse {
+  id: number;
+  email: string;
+  name: string;
+  profile_image: string;
+  provider: string;
+  created_at: string;
+}
+
+export const authApi = baseApi.injectEndpoints({
+  endpoints: (builder) => ({
+    register: builder.mutation<RegisterResponse, RegisterRequest>({
+      query: (body) => ({
+        url: "auth/register/",
+        method: "POST",
+        body,
+      }),
+    }),
+  }),
+});
+
+export const { useRegisterMutation } = authApi;

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -1,14 +1,65 @@
+import { useState } from "react";
+import { useRegisterMutation } from "@/features/api/authApi";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";
 import { FcGoogle } from "react-icons/fc";
+import { useNavigate } from "react-router-dom";
 
 export const SignupPage = () => {
+  const navigate = useNavigate();
+  const [form, setForm] = useState({
+    name: "",
+    email: "",
+    password: "",
+    password2: "",
+    agree: false,
+  });
+
+  const [register, { isLoading }] = useRegisterMutation();
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { id, value, type, checked } = e.target;
+    setForm((prev) => ({
+      ...prev,
+      [id]: type === "checkbox" ? checked : value,
+    }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!form.agree) {
+      alert("약관에 동의해야 가입할 수 있습니다.");
+      return;
+    }
+
+    if (form.password !== form.password2) {
+      alert("비밀번호가 일치하지 않습니다.");
+      return;
+    }
+
+    try {
+      await register({
+        name: form.name,
+        email: form.email,
+        password: form.password,
+        password2: form.password2,
+      }).unwrap();
+      alert("회원가입 성공!");
+      // 회원가입 성공 후 리다이렉트 또는 추가 작업
+      navigate("/login");
+    } catch (err) {
+      console.error("회원가입 실패", err);
+      alert("회원가입 중 오류가 발생했습니다.");
+    }
+  };
+
   return (
     <div className="flex items-center justify-center min-h-screen px-4 bg-white">
-      <div className="w-full max-w-md space-y-6">
+      <form onSubmit={handleSubmit} className="w-full max-w-md space-y-6">
         {/* 제목 */}
         <h1 className="text-2xl font-bold text-left text-gray-900">회원가입</h1>
 
@@ -17,7 +68,14 @@ export const SignupPage = () => {
           <Label htmlFor="name">
             이름<span className="ml-1 text-red-500">*</span>
           </Label>
-          <Input id="name" type="text" placeholder="이름" required />
+          <Input
+            id="name"
+            type="text"
+            placeholder="이름"
+            value={form.name}
+            onChange={handleChange}
+            required
+          />
         </div>
 
         {/* 이메일 */}
@@ -25,7 +83,14 @@ export const SignupPage = () => {
           <Label htmlFor="email">
             이메일<span className="ml-1 text-red-500">*</span>
           </Label>
-          <Input id="email" type="email" placeholder="이메일" required />
+          <Input
+            id="email"
+            type="email"
+            placeholder="이메일"
+            value={form.email}
+            onChange={handleChange}
+            required
+          />
         </div>
 
         {/* 비밀번호 */}
@@ -37,21 +102,48 @@ export const SignupPage = () => {
             id="password"
             type="password"
             placeholder="비밀번호"
+            value={form.password}
+            onChange={handleChange}
+            required
+          />
+        </div>
+
+        {/* 비밀번호 확인 */}
+        <div className="space-y-1 text-left">
+          <Label htmlFor="password2">
+            비밀번호 확인<span className="ml-1 text-red-500">*</span>
+          </Label>
+          <Input
+            id="password2"
+            type="password"
+            placeholder="비밀번호 확인"
+            value={form.password2}
+            onChange={handleChange}
             required
           />
         </div>
 
         {/* 약관 동의 */}
         <div className="flex items-center gap-2 text-sm text-left">
-          <Checkbox id="agree" />
+          <Checkbox
+            id="agree"
+            checked={form.agree}
+            onCheckedChange={(checked) => {
+              setForm((prev) => ({ ...prev, agree: checked === true }));
+            }}
+          />
           <Label htmlFor="agree" className="text-gray-700">
             서비스 이용약관에 동의합니다.
           </Label>
         </div>
 
         {/* 회원가입 버튼 */}
-        <Button className="w-full text-white bg-blue-600 hover:bg-blue-700">
-          회원가입
+        <Button
+          type="submit"
+          className="w-full text-white bg-blue-600 hover:bg-blue-700"
+          disabled={isLoading}
+        >
+          {isLoading ? "가입 중..." : "회원가입"}
         </Button>
 
         {/* 구분선 */}
@@ -63,6 +155,7 @@ export const SignupPage = () => {
 
         {/* 구글 로그인 */}
         <Button
+          type="button"
           variant="outline"
           className="flex items-center justify-center w-full gap-2 bg-gray-100 hover:bg-gray-200"
         >
@@ -80,7 +173,7 @@ export const SignupPage = () => {
             서비스 약관
           </a>
         </div>
-      </div>
+      </form>
     </div>
   );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -931,6 +931,13 @@ argparse@^2.0.1:
   resolved "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
+async-mutex@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/async-mutex/-/async-mutex-0.5.0.tgz#353c69a0b9e75250971a64ac203b0ebfddd75482"
+  integrity sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==
+  dependencies:
+    tslib "^2.4.0"
+
 autoprefixer@^10.4.21:
   version "10.4.21"
   resolved "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.21.tgz"
@@ -2633,6 +2640,11 @@ ts-interface-checker@^0.1.9:
   version "0.1.13"
   resolved "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz"
   integrity sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==
+
+tslib@^2.4.0:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
+  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
 
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #33 

## 📝작업 내용

> [API Endpoint 설정](https://github.com/inable-it/inable_dashboard/commit/c1628fecd2042d0694c5d70b6970cd84da8fda1e)
> [RTK Query 설정](https://github.com/inable-it/inable_dashboard/commit/bcb498733348d85f2be676033c0c282f7700a207)
> [회원가입 api 연동 & 회원가입 후 토큰 헤더에 설정 & 로그인페이지 이동](https://github.com/inable-it/inable_dashboard/commit/7e64f5f015745e08ee82a7a1910178efd8f8fb1f)
> [async-mutex 활용 중복 refresh 요청 방지](https://github.com/inable-it/inable_dashboard/commit/8e77dcb5a14b7b852019929bb284696ea978761e)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
