### PR TITLE
Feat/#39

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,2 @@
 VITE_API_BASE_URL=https://webridge-backend-development.up.railway.app/api/v1/
+VITE_GOOGLE_CLIENT_ID=425962390625-vjg63slgeg84b6r9ci6g4nls25j9e8dv.apps.googleusercontent.com

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-separator": "^1.1.7",
     "@radix-ui/react-slot": "^1.2.2",
+    "@react-oauth/google": "^0.12.2",
     "@reduxjs/toolkit": "^2.8.1",
     "async-mutex": "^0.5.0",
     "class-variance-authority": "^0.7.1",

--- a/src/components/common/GoogleLoginButton.tsx
+++ b/src/components/common/GoogleLoginButton.tsx
@@ -1,0 +1,34 @@
+import { useGoogleLogin } from "@react-oauth/google";
+import { useSocialLoginMutation } from "@/features/api/authApi";
+
+const GoogleLoginButton = () => {
+  const [socialLogin] = useSocialLoginMutation();
+
+  const login = useGoogleLogin({
+    flow: "implicit",
+    onSuccess: async (tokenResponse) => {
+      try {
+        const response = await socialLogin({
+          provider: "google",
+          access_token: tokenResponse.access_token,
+        }).unwrap();
+        console.log("소셜 로그인 성공", response);
+      } catch (error) {
+        console.error("소셜 로그인 실패", error);
+      }
+    },
+    onError: () => console.log("Google Login 실패"),
+  });
+
+  return (
+    <button
+      onClick={() => login()}
+      className="flex items-center justify-center gap-4 w-full h-[50px] rounded-lg bg-[#f5f5f5] hover:bg-[#e0e0e0] shadow text-[#3c4043] text-[16px] font-medium"
+    >
+      <img src="/public/google.svg" alt="Google Logo" className="w-6 h-6" />
+      Google로 계속하기
+    </button>
+  );
+};
+
+export default GoogleLoginButton;

--- a/src/features/api/authApi.ts
+++ b/src/features/api/authApi.ts
@@ -15,7 +15,15 @@ interface RegisterResponse {
   provider: string;
   created_at: string;
 }
+interface SocialLoginRequest {
+  provider: "google";
+  access_token: string;
+}
 
+interface SocialLoginResponse {
+  access: string; // access token
+  refresh: string; // refresh token
+}
 export const authApi = baseApi.injectEndpoints({
   endpoints: (builder) => ({
     register: builder.mutation<RegisterResponse, RegisterRequest>({
@@ -25,7 +33,14 @@ export const authApi = baseApi.injectEndpoints({
         body,
       }),
     }),
+    socialLogin: builder.mutation<SocialLoginResponse, SocialLoginRequest>({
+      query: (body) => ({
+        url: "auth/social-login/",
+        method: "POST",
+        body,
+      }),
+    }),
   }),
 });
 
-export const { useRegisterMutation } = authApi;
+export const { useRegisterMutation, useSocialLoginMutation } = authApi;

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -3,6 +3,8 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Link } from "react-router-dom";
+import { GoogleOAuthProvider } from "@react-oauth/google";
+import GoogleLoginButton from "@/components/common/GoogleLoginButton";
 
 const LoginPage = () => {
   return (
@@ -54,13 +56,9 @@ const LoginPage = () => {
         </div>
 
         {/* 구글 로그인 버튼 */}
-        <button
-          type="button"
-          className="flex items-center justify-center w-full gap-2 px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 border border-gray-300 rounded-md hover:bg-gray-200"
-        >
-          <img src="/google.svg" alt="Google" className="w-5 h-5" />
-          Google로 계속하기
-        </button>
+        <GoogleOAuthProvider clientId={import.meta.env.VITE_GOOGLE_CLIENT_ID}>
+          <GoogleLoginButton />
+        </GoogleOAuthProvider>
       </div>
     </div>
   );

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -5,8 +5,9 @@ import { Input } from "@/components/ui/input";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";
-import { FcGoogle } from "react-icons/fc";
 import { useNavigate } from "react-router-dom";
+import { GoogleOAuthProvider } from "@react-oauth/google";
+import GoogleLoginButton from "@/components/common/GoogleLoginButton";
 
 export const SignupPage = () => {
   const navigate = useNavigate();
@@ -154,14 +155,9 @@ export const SignupPage = () => {
         </div>
 
         {/* 구글 로그인 */}
-        <Button
-          type="button"
-          variant="outline"
-          className="flex items-center justify-center w-full gap-2 bg-gray-100 hover:bg-gray-200"
-        >
-          <FcGoogle className="w-5 h-5" />
-          Google로 계속하기
-        </Button>
+        <GoogleOAuthProvider clientId={import.meta.env.VITE_GOOGLE_CLIENT_ID}>
+          <GoogleLoginButton />
+        </GoogleOAuthProvider>
 
         {/* 약관 링크 */}
         <div className="flex justify-center gap-4 mt-2 text-xs text-gray-500">

--- a/yarn.lock
+++ b/yarn.lock
@@ -577,6 +577,11 @@
   dependencies:
     "@radix-ui/react-use-layout-effect" "1.1.1"
 
+"@react-oauth/google@^0.12.2":
+  version "0.12.2"
+  resolved "https://registry.yarnpkg.com/@react-oauth/google/-/google-0.12.2.tgz#082086fcfac1309e4e66413e7a30d24f452445e9"
+  integrity sha512-d1GVm2uD4E44EJft2RbKtp8Z1fp/gK8Lb6KHgs3pHlM0PxCXGLaq8LLYQYENnN4xPWO1gkL4apBtlPKzpLvZwg==
+
 "@reduxjs/toolkit@^2.8.1":
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/@reduxjs/toolkit/-/toolkit-2.8.1.tgz#85a50572627bce1e6cfbc3803b31a3290f5f344d"


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #39 

## 📝작업 내용

> GoogleOAuthProvider에 Client ID 넣고 감싸기
> @react-oauth/google가 제공하는 useGoogleLogin 훅 사용
> RTK Query API 연동: 존 authApi에 socialLogin mutation 추가
> 직접 커스텀 버튼 생성 후 소셜 로그인 호출

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
