### PR TITLE
Fix/#53

### DIFF
--- a/src/app/api.ts
+++ b/src/app/api.ts
@@ -1,14 +1,18 @@
-import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
-import type { BaseQueryFn } from "@reduxjs/toolkit/query";
+import {
+  createApi,
+  fetchBaseQuery,
+  type BaseQueryFn,
+} from "@reduxjs/toolkit/query/react";
 import { Mutex } from "async-mutex";
 
-// 동시 refresh 요청 방지를 위한 뮤텍스
+// refresh 중복 요청 방지용 Mutex 생성
 const mutex = new Mutex();
 
-// 기본 baseQuery (Authorization 헤더 포함)
+// 일반 API 요청 시 항상 이 baseQuery를 사용함
 const baseQuery = fetchBaseQuery({
   baseUrl: import.meta.env.VITE_API_BASE_URL,
   prepareHeaders: (headers) => {
+    // accessToken이 있으면 Authorization 헤더에 포함
     const token = localStorage.getItem("accessToken");
     if (token) {
       headers.set("Authorization", `Bearer ${token}`);
@@ -17,22 +21,28 @@ const baseQuery = fetchBaseQuery({
   },
 });
 
-// 커스텀 baseQuery - accessToken 만료 시 refreshToken으로 자동 갱신
-const customBaseQuery: BaseQueryFn = async (args, api, extraOptions) => {
-  await mutex.waitForUnlock();
+// customBaseQuery: refresh 토큰 자동 갱신 포함 버전
+export const customBaseQuery: BaseQueryFn = async (args, api, extraOptions) => {
+  await mutex.waitForUnlock(); // 다른 refresh 중이라면 대기
 
   let result = await baseQuery(args, api, extraOptions);
 
+  // 401 → accessToken 만료 의심
   if (result.error?.status === 401) {
     if (!mutex.isLocked()) {
-      const release = await mutex.acquire();
+      const release = await mutex.acquire(); // refresh 중복 방지 잠금
 
       try {
         const refreshToken = localStorage.getItem("refreshToken");
+        if (!refreshToken) {
+          // refreshToken 없으면 바로 실패
+          return { error: { status: 401, data: "No refresh token" } };
+        }
 
+        // refresh API 호출
         const refreshResult = await baseQuery(
           {
-            url: "auth/token/refresh/",
+            url: "/api/v1/auth/token/refresh/",
             method: "POST",
             body: { refresh: refreshToken },
           },
@@ -43,16 +53,21 @@ const customBaseQuery: BaseQueryFn = async (args, api, extraOptions) => {
         const refreshData = refreshResult.data as { access: string };
 
         if (refreshData?.access) {
+          // 새 accessToken 저장
           localStorage.setItem("accessToken", refreshData.access);
+          // 원래 실패했던 요청 재시도
           result = await baseQuery(args, api, extraOptions);
         } else {
+          // refresh 실패 → 로그아웃 처리
           localStorage.removeItem("accessToken");
           localStorage.removeItem("refreshToken");
+          return { error: { status: 401, data: "Token refresh failed" } };
         }
       } finally {
-        release();
+        release(); // unlock
       }
     } else {
+      // 다른 refresh 요청 대기
       await mutex.waitForUnlock();
       result = await baseQuery(args, api, extraOptions);
     }
@@ -61,8 +76,18 @@ const customBaseQuery: BaseQueryFn = async (args, api, extraOptions) => {
   return result;
 };
 
-// RTK Query API 인스턴스 정의
-export const baseApi = createApi({
+// 인증이 필요없는 API 요청용 (로그인, 회원가입, 소셜로그인, 로그아웃)
+export const publicApi = createApi({
+  reducerPath: "publicApi",
+  baseQuery: fetchBaseQuery({
+    baseUrl: import.meta.env.VITE_API_BASE_URL,
+  }),
+  endpoints: () => ({}),
+});
+
+// 인증이 필요한 보호 API 요청용 (refresh 자동 포함됨)
+export const privateApi = createApi({
+  reducerPath: "privateApi",
   baseQuery: customBaseQuery,
   endpoints: () => ({}),
 });

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -1,39 +1,33 @@
-import { combineReducers, configureStore } from "@reduxjs/toolkit";
-import { baseApi } from "@/app/api";
+import { configureStore, combineReducers } from "@reduxjs/toolkit";
 import userReducer from "@/features/store/userSlice";
 import menuReducer from "@/features/store/menuSlice";
-
-import { persistStore, persistReducer } from "redux-persist";
+import { publicApi, privateApi } from "@/app/api";
 import storage from "redux-persist/lib/storage";
+import { persistStore, persistReducer } from "redux-persist";
 
-// 먼저 combineReducers로 여러 reducer 통합
 const rootReducer = combineReducers({
   user: userReducer,
   menu: menuReducer,
-  [baseApi.reducerPath]: baseApi.reducer,
+  [publicApi.reducerPath]: publicApi.reducer,
+  [privateApi.reducerPath]: privateApi.reducer,
 });
 
-// persist 설정
 const persistConfig = {
   key: "root",
   storage,
-  whitelist: ["user"], // user slice만 저장
+  whitelist: ["user", "menu"],
 };
 
-// persistReducer 적용
 const persistedReducer = persistReducer(persistConfig, rootReducer);
 
-// 최종 store 생성
 export const store = configureStore({
   reducer: persistedReducer,
   middleware: (getDefaultMiddleware) =>
-    getDefaultMiddleware({
-      serializableCheck: false,
-    }).concat(baseApi.middleware),
-  devTools: true,
+    getDefaultMiddleware({ serializableCheck: false })
+      .concat(publicApi.middleware)
+      .concat(privateApi.middleware),
 });
 
 export const persistor = persistStore(store);
-
 export type RootState = ReturnType<typeof store.getState>;
 export type AppDispatch = typeof store.dispatch;

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -2,9 +2,10 @@ import { useNavigate } from "react-router-dom";
 import { useSelector, useDispatch } from "react-redux";
 import { useState } from "react";
 import type { RootState } from "@/app/store";
-import { useLogoutMutation } from "@/features/api/authApi";
+import { useLogoutMutation } from "@/features/api/authApi"; // publicApi 기반 hook
 import { clearUser } from "@/features/store/userSlice";
 import { toast } from "@/hooks/use-toast";
+import { publicApi } from "@/app/api"; // publicApi에서 resetApiState 호출
 
 export const Header = () => {
   const navigate = useNavigate();
@@ -15,17 +16,19 @@ export const Header = () => {
 
   const handleLogout = async () => {
     try {
-      const refreshToken = localStorage.getItem("refreshToken");
+      const refreshToken =
+        localStorage.getItem("refreshToken") ||
+        localStorage.getItem("refresh_token");
+      console.log("로그아웃 시도, refreshToken:", refreshToken);
 
-      if (!refreshToken) {
-        throw new Error("No refresh token found.");
-      }
-
-      await logout({ refresh: refreshToken }).unwrap();
+      await logout({ refresh: refreshToken ?? "" }).unwrap();
 
       localStorage.removeItem("accessToken");
       localStorage.removeItem("refreshToken");
       dispatch(clearUser());
+
+      // publicApi 캐시 초기화
+      dispatch(publicApi.util.resetApiState());
 
       toast({
         title: "로그아웃 성공",

--- a/src/features/api/authApi.ts
+++ b/src/features/api/authApi.ts
@@ -1,94 +1,55 @@
-import { baseApi } from "@/app/api";
-
-interface RegisterRequest {
-  email: string;
-  password: string;
-  password2: string;
-  name: string;
-}
-
-interface RegisterResponse {
-  id: number;
-  email: string;
-  name: string;
-  profile_image: string;
-  provider: string;
-  created_at: string;
-}
-
-interface SocialLoginRequest {
-  provider: "google";
-  access_token: string;
-}
+import { publicApi, privateApi } from "@/app/api";
 
 interface User {
   id: number;
   email: string;
   name: string;
-  profile_image: string;
+  profile_image: string | null;
   provider: string;
   created_at: string;
-}
-
-interface SocialLoginResponse {
-  user: User;
-  access: string;
-  refresh: string;
-  is_new: boolean;
-}
-
-interface LoginRequest {
-  email: string;
-  password: string;
 }
 
 interface LoginResponse {
   user: User;
   access: string;
   refresh: string;
-  is_new: boolean;
 }
 
-interface LogoutRequest {
-  refresh: string;
-}
-
-export const authApi = baseApi.injectEndpoints({
+// public 인증 API (로그인/회원가입/소셜로그인만)
+export const authPublicApi = publicApi.injectEndpoints({
   endpoints: (builder) => ({
-    register: builder.mutation<RegisterResponse, RegisterRequest>({
-      query: (body) => ({
-        url: "auth/register/",
-        method: "POST",
-        body,
-      }),
+    register: builder.mutation<
+      LoginResponse,
+      { email: string; password: string; password2: string; name: string }
+    >({
+      query: (body) => ({ url: "auth/register/", method: "POST", body }),
     }),
-    socialLogin: builder.mutation<SocialLoginResponse, SocialLoginRequest>({
-      query: (body) => ({
-        url: "auth/social-login/",
-        method: "POST",
-        body,
-      }),
-    }),
-    login: builder.mutation<LoginResponse, LoginRequest>({
-      query: (body) => ({
-        url: "auth/login/",
-        method: "POST",
-        body,
-      }),
-    }),
-    logout: builder.mutation<void, LogoutRequest>({
-      query: (body) => ({
-        url: "auth/logout/",
-        method: "POST",
-        body,
-      }),
+    login: builder.mutation<LoginResponse, { email: string; password: string }>(
+      {
+        query: (body) => ({ url: "auth/login/", method: "POST", body }),
+      }
+    ),
+    socialLogin: builder.mutation<
+      LoginResponse,
+      { provider: string; access_token: string }
+    >({
+      query: (body) => ({ url: "auth/social-login/", method: "POST", body }),
     }),
   }),
+  overrideExisting: false,
 });
 
-export const {
-  useRegisterMutation,
-  useSocialLoginMutation,
-  useLoginMutation,
-  useLogoutMutation,
-} = authApi;
+// private 인증 API (로그아웃은 보호 API)
+export const authPrivateApi = privateApi.injectEndpoints({
+  endpoints: (builder) => ({
+    logout: builder.mutation<void, { refresh: string }>({
+      query: (body) => ({ url: "auth/logout/", method: "POST", body }),
+    }),
+  }),
+  overrideExisting: false,
+});
+
+export const { useRegisterMutation, useLoginMutation, useSocialLoginMutation } =
+  authPublicApi;
+
+export const { useLogoutMutation } = authPrivateApi;

--- a/src/features/store/userSlice.ts
+++ b/src/features/store/userSlice.ts
@@ -1,10 +1,11 @@
 import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
 
+// 유저 상태 타입
 interface User {
   id: number;
   email: string;
   name: string;
-  profile_image: string;
+  profile_image: string | null;
   provider: string;
   created_at: string;
 }
@@ -13,23 +14,21 @@ interface UserState {
   user: User | null;
 }
 
-const initialState: UserState = {
-  user: null,
-};
+const initialState: UserState = { user: null };
 
+// 유저 상태 전역 관리
 export const userSlice = createSlice({
   name: "user",
   initialState,
   reducers: {
-    setUser: (state, action: PayloadAction<User>) => {
+    setUser(state, action: PayloadAction<User>) {
       state.user = action.payload;
     },
-    clearUser: (state) => {
+    clearUser(state) {
       state.user = null;
     },
   },
 });
 
 export const { setUser, clearUser } = userSlice.actions;
-
 export default userSlice.reducer;


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #53 

## 📝작업 내용

1. 인증 흐름 설계
   - Refresh Token 기반 인증 시스템 설계
   - Access Token 자동 갱신 (401 발생시 Refresh 요청)
2. API 구조 분리
3. RTK Query API 구축
   - customBaseQuery (핵심 refresh 처리 담당)
      - refresh 중복 요청 방지 위해 async-mutex 사용
      - 401 발생 시 refresh 토큰 요청 → accessToken 갱신 → 실패 시 토큰 초기화
   - publicApi
      - 인증 필요 없는 API용
      - prepareHeaders 포함 (혹시라도 Authorization 필요한 API를 위해)
    - privateApi
      - 인증 필요한 API용
      - customBaseQuery 사용 → 자동 갱신
4. authApi 구조 완전 분리
   - publicApi → register, login, socialLogin 담당
   - privateApi → logout 담당
5. Redux Store 구성
   - Redux Persist 적용 → 새로고침해도 로그인 유지
   - userSlice: 유저 정보 전역 관리
   - menuSlice: LNB 메뉴 전역 관리
### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
